### PR TITLE
Adjust toolstack to use more general PCI reset.

### DIFF
--- a/xenops/device.ml
+++ b/xenops/device.ml
@@ -1150,9 +1150,9 @@ let read_dev_class dev =
 
 let do_flr dev =
   let devstr = string_of_desc dev.desc in
-  let p = "/sys/bus/pci/drivers/pciback/" ^ devstr ^ "/reset" in
-  debug "Device.Pci.do_flr %s" devstr;
-  (try write_string_to_file p "1" with _ -> debug "Device.Pci.do_flr %s FAILED" devstr);
+  let p = "/sys/bus/pci/drivers/pciback/reset_device" in
+  debug "Device.Pci.do_flr %s via reset_device" devstr;
+  (try write_string_to_file p devstr with _ -> debug "Device.Pci.do_flr %s FAILED" devstr);
   debug "Device.Pci.do_flr %s done" devstr
 
 (* set pciback configuration space policy for this device to permissive *)


### PR DESCRIPTION
A new set of kernel patches add a more general PCI reset technique that
works with devices that lack FLR and properly-implemented
power-management reset techniques. This patch adjusts the 
toolstack to use the more general resets instead of the linux kernel's 
built in reset.

This supports PCI passthrough of GPUs; many of which support neither
FLR not power management resets-- and which can wind up in
non-functional states after unclean VM shutdowns. By using our expanded
reset, many of these devices now can be stood up correctly following an
incomplete VM shutdown.

Signed-off-by: Kyle J. Temkin temkink@ainfosec.com
