### PR TITLE
Estimate PCI hole size before starting QEMU

### DIFF
--- a/xenops/device.ml
+++ b/xenops/device.ml
@@ -1171,6 +1171,18 @@ let set_restrictive dev =
   (try write_string_to_file p devstr with _ -> debug "Device.Pci.switch_restrictive %s FAILED" devstr);
   debug "Device.Pci.switch_restrictive %s done" devstr
 
+let mmio pcidev =
+    let (irq, resources, driver) = get_from_system pcidev.desc in
+    List.filter (fun (base, limit, flags) ->
+        (Int64.logand flags 0x1L) = 0x0L
+    ) resources
+
+let io pcidev =
+    let (irq, resources, driver) = get_from_system pcidev.desc in
+    List.filter (fun (base, limit, flags) ->
+        (Int64.logand flags 0x1L) = 0x1L
+    ) resources
+
 let add_noexn ~xc ~xs ~hvm ?(assign=true) ?(pvpci=true) ?(flr=false) ?(permissive=false) pcidevs_list domid devid =
 	let msitranslate = (List.hd pcidevs_list).msitranslate in
 	let power_mgmt   = (List.hd pcidevs_list).power_mgmt in

--- a/xenops/device.mli
+++ b/xenops/device.mli
@@ -202,6 +202,9 @@ sig
 	val bind : dev list -> unit
 	val plug : xc:Xc.handle -> xs:Xs.xsh -> dev -> Xc.domid -> int -> unit
 	val unplug : xc:Xc.handle -> xs:Xs.xsh -> dev -> Xc.domid -> int -> unit
+
+        val mmio : dev -> (int64 * int64 * int64) list
+        val io : dev -> (int64 * int64 * int64) list
 end
 
 module Vfb :

--- a/xenvm/vmact.ml
+++ b/xenvm/vmact.ml
@@ -687,7 +687,8 @@ let add_devices xc xs domid state restore =
 			let mmio_size dev =
 				let rec __mmio_size res = match res with
 				| [] -> 0L
-				| (base, limit, _)::l -> debug "%Lx - %Lx = %Lx " limit base (Int64.sub limit base); Int64.add (Int64.sub limit base) (__mmio_size l)
+				| (base, limit, _)::l ->
+                                        Int64.add (Int64.sub (Int64.add limit 1L) base) (__mmio_size l)
 				in __mmio_size (Device.PCI.mmio dev)
 			in
 			let mmio_size_total cfg_pcis =
@@ -697,11 +698,11 @@ let add_devices xc xs domid state restore =
 				List.fold_left (fun acc (devid, cfg_devs) ->
 					let pcidevs = List.map (fun dev ->
 						xenops_pci_of_pci cfg dev
-				) cfg_devs in
-					Int64.add acc (__mmio_size_total pcidevs)
-					) 32L cfg_pcis
-				(* We assume 32MB are required for QEMU default configuration. *)
-					in
+				        ) cfg_devs in
+                                        Int64.add acc (__mmio_size_total pcidevs)
+				) 0x2000000L cfg_pcis
+				(* We assume 32MB (0x2000000B) are required for QEMU default configuration. *)
+			in
 			let pci_hole_size = mmio_size_total pcis in
 			let rec pci_hole_base_adjust base size =
 				(* HVMLOADER assumes the PCI hole cannot grow below the 2G limit. *)


### PR DESCRIPTION
Add a XenStore node with the expected top of RAM address below the 32b
address range limit. dm-agent will then pass it to QEMU.

The estimation is made based on 3 assumptions:
- Default QEMU configuration does not require more than 32MB PCI hole
- The PCI hole cannot grow bigger than 2GB
- The "default" PCI hole is 0xf0000000-0xfc000000 (see xen e820.h)

Hvmloader will re-process that value. It is unclear if we should let
that happen or patch it. For now we should always find the same value
and stay consistent.

The full fix for OXT-243 includes the modification in dm-agent to pass it from Xenstore to QEMU command line and the QEMU patch to notify the Xen memory listener and the i440fx emulation.
