### PR TITLE
Toolstack support for ACPI shutdown without tools.

### DIFF
--- a/xenvm/vmact.ml
+++ b/xenvm/vmact.ml
@@ -919,6 +919,7 @@ let shutdown_vm xc xs xal state force reason =
 			| Xal.Vanished, _ -> true
 			| Xal.Halted, (Domain.Halt | Domain.PowerOff) -> true
 			| Xal.Rebooted, Domain.Reboot       -> true
+			| Xal.Halted, Domain.Reboot         -> true
 			| Xal.Suspended, Domain.Suspend     -> true
 			| Xal.Shutdown i, Domain.Unknown i2 -> i = i2
 			| _ -> false


### PR DESCRIPTION
domain.ml:
- In hvm case, only do hard shutdown if guest is in s3. ACPI support
  now allows guest to poweroff without PV drivers.

vmact.ml:
- Add extra case to do reboot if Xal reports Halt and toolstack reports
  reboot.  ACPI has no concept of 'reboot', so 'halt' status is returned
  after the domain is shutdown. In this unique case, don't report it as
  an error.

OXT-212

Signed-off-by: Chris Rogers rogersc@ainfosec.com
