### PR TITLE
Allow Stubdomain configuration of a given VM through the toolstack

### DIFF
--- a/xenops/dmagent.ml
+++ b/xenops/dmagent.ml
@@ -358,7 +358,7 @@ let create_devmodel ~xs ~timeout info domid dmaid dmid dminfo =
 let create_stubdomain ~xc ~xs ~timeout info target_domid uuid =
 	let use_qemu_dm = try ignore (Unix.stat "/config/qemu-dm"); [ "qemu-dm" ]
 					  with _ -> [] in
-	let args = ["dmagent"; sprintf "%u" target_domid] @ use_qemu_dm in
+	let args = ["guest_agent=dmagent"; sprintf "guest_domid=%u" target_domid] @ use_qemu_dm in
 	let stubdom_domid = Dm.create_dm_stubdom ~xc ~xs args info target_domid uuid in
 	(* Wait that dm-agent has been created *)
 	let waitpath = dmagent_path (string_of_int stubdom_domid) "capabilities" in

--- a/xenvm/vmconfig.ml
+++ b/xenvm/vmconfig.ml
@@ -815,7 +815,7 @@ let empty =
 		stubdom_memory = 64L;
 		stubdom_initrd = Some "/usr/lib/xen/boot/stubdomain-initramfs";
 		stubdom_kernel = "/usr/lib/xen/boot/stubdomain-bzImage";
-		stubdom_cmdline = "";
+		stubdom_cmdline = "init=/init xen_blkfront.max=8";
 		qemu_dm_path = "";
 		qemu_dm_timeout = 30;
 		bios_strings = [];

--- a/xenvm/vmconfig.ml
+++ b/xenvm/vmconfig.ml
@@ -834,7 +834,8 @@ let of_file uuid error_report file =
 	and output = ref (!cfg.output)
 	and no_mem_check = ref (!cfg.no_mem_check)
 	and memory = ref (-1)
-	and stubdom_memory = ref (Int64.to_int empty.stubdom_memory)
+	and stubdom_memory = ref (Int64.to_int !cfg.stubdom_memory)
+        and stubdom_cmdline = ref (!cfg.stubdom_cmdline)
 		in
 
 	let action_of_string s =
@@ -860,6 +861,7 @@ let of_file uuid error_report file =
 		("debug", Config.Set_bool debug);
 		("memory", Config.Set_int memory);
 		("stubdom-memory", Config.Set_int stubdom_memory);
+                ("stubdom-cmdline", Config.String (fun s -> stubdom_cmdline := String.concat " " [!stubdom_cmdline; s]));
 		("no_mem_check", Config.Set_bool no_mem_check);
 	] in
 	let kv k v =
@@ -889,6 +891,7 @@ let of_file uuid error_report file =
 		memory = Int64.mul (Int64.of_int !memory) 1024L;
 		memory_max = (match !cfg.memory_max with None -> None | Some x -> Some (Int64.mul x 1024L));
 		stubdom_memory = Int64.mul (Int64.of_int !stubdom_memory) 1024L;
+                stubdom_cmdline = !stubdom_cmdline;
 		startup = !startup;
 		output = !output;
 		nics = nics;

--- a/xenvm/vmconfig.ml
+++ b/xenvm/vmconfig.ml
@@ -815,7 +815,7 @@ let empty =
 		stubdom_memory = 64L;
 		stubdom_initrd = Some "/usr/lib/xen/boot/stubdomain-initramfs";
 		stubdom_kernel = "/usr/lib/xen/boot/stubdomain-bzImage";
-		stubdom_cmdline = "init=/init xen_blkfront.max=8";
+		stubdom_cmdline = "";
 		qemu_dm_path = "";
 		qemu_dm_timeout = 30;
 		bios_strings = [];
@@ -861,7 +861,7 @@ let of_file uuid error_report file =
 		("debug", Config.Set_bool debug);
 		("memory", Config.Set_int memory);
 		("stubdom-memory", Config.Set_int stubdom_memory);
-                ("stubdom-cmdline", Config.String (fun s -> stubdom_cmdline := String.concat " " [!stubdom_cmdline; s]));
+                ("stubdom-cmdline", Config.String (fun s -> stubdom_cmdline := s));
 		("no_mem_check", Config.Set_bool no_mem_check);
 	] in
 	let kv k v =


### PR DESCRIPTION
Add missing logic to set in xenvm's configuration file:
- stubdom-cmdline:
  - cmdline to be appended to the stubdomain's default cmdline.
    Default: init=/init xen_blkfront.max=8 [<stubdom-cmdline>] dmagent <domid>
    (Default cmdline is hardcoded apparently)
- stubdom-memory:
  - Memory given to the stubdomain, in megabytes.

OXT-332

See related PR in:
- xenclient-oe.git
- manager.git
- idl.git
