### PR TITLE
Clean up destruction of domains with PCI devices.

### DIFF
--- a/xenops/device.ml
+++ b/xenops/device.ml
@@ -1289,17 +1289,8 @@ let release ~xc ~xs ~hvm pcidevs domid devid =
 
 	List.iter (fun (dev, resources) ->
 		free domid dev resources hvm
-	) pcidevs;
+	) pcidevs
 
-	let device = {
-		backend = { domid = 0; kind = Pci; devid = devid };
-		frontend = { domid = domid; kind = Pci; devid = devid };
-	} in
-	let backend_path = backend_path_of_device ~xs device in
-	let flr = try (xs.Xs.read (backend_path ^ "/flr")) with _ -> "0" in
-	if flr = "1" then (
-		List.iter (fun (dev, resources) -> do_flr dev) pcidevs;
-	)
 
 let bind pcidevs =
 	let bind_to_pciback device =

--- a/xenops/device.mli
+++ b/xenops/device.mli
@@ -202,6 +202,8 @@ sig
 	val bind : dev list -> unit
 	val plug : xc:Xc.handle -> xs:Xs.xsh -> dev -> Xc.domid -> int -> unit
 	val unplug : xc:Xc.handle -> xs:Xs.xsh -> dev -> Xc.domid -> int -> unit
+	val enumerate_devs : xs:Xs.xsh -> (device) -> dev list
+	val do_flr : dev -> unit
 
         val mmio : dev -> (int64 * int64 * int64) list
         val io : dev -> (int64 * int64 * int64) list


### PR DESCRIPTION
This pull request makes two slight modifications to domain destruction:
- PCI device resets ("FLRs") are deferred until all devices have
  been detached from the target domain. This enables resets to go
  through even for multi-function devices that require an SBR, as
  all of their functions will be released when the reset occurs.
- Domain destruction is deferred until all of the PCI devices are
  detached. This cleans up a fair number of Xen error messages,
  and ensures that all PCI-tracking metadata is freed in the
  hypervisor. (Earlier, the domains were destroyed /before/ their
  devices were freed-- resulting in Xen losing its references to
  the PCI device data. The later request to free failed, as Xen
  didn't recognize the domid.)
