### PR TITLE
Signal to QEMU that a domain should be awoken after S3.

### DIFF
--- a/xenops/domain.mli
+++ b/xenops/domain.mli
@@ -180,7 +180,7 @@ val suspend: xc: Xc.handle -> xs: Xs.xsh -> hvm: bool -> domid
 val make_stubdom: xc: Xc.handle -> xs: Xs.xsh -> ioemuargs:string list -> stubdom_info -> [`domain] Uuid.t -> domid
 
 (** send a s3resume event to a domain *)
-val send_s3resume: xc: Xc.handle -> domid -> unit
+val send_s3resume: xc: Xc.handle -> xs: Xs.xsh -> domid -> unit
 
 (** Set cpu affinity of some vcpus of a domain using an boolean array *)
 val vcpu_affinity_set: xc: Xc.handle -> domid -> int -> bool array -> unit

--- a/xenops/domain_common.ml
+++ b/xenops/domain_common.ml
@@ -550,7 +550,10 @@ let pause ~xc domid =
 let unpause ~xc domid =
 	Xc.domain_unpause xc domid
 
-let send_s3resume ~xc domid = Xc.domain_send_s3resume xc domid
+(* wake a provided domain up from s3 *)
+let send_s3resume ~xc ~xs domid =
+	Xc.domain_send_s3resume xc domid;
+	xs.Xs.write (xs.Xs.getdomainpath domid ^ "/wakeup-req") "1"
 
 let make_stubdom ~xc ~xs ~ioemuargs info uuid =
       let ssidref =

--- a/xenvm/vmact.ml
+++ b/xenvm/vmact.ml
@@ -823,7 +823,7 @@ let set_cores_per_socket xc domid cfg =
 		  with exn -> warn "exception ignored during cores-per-socket setting: %s" (Printexc.to_string exn)
 		  
 		  
-let do_trigger xc state args =
+let do_trigger xc xs state args =
 	match args with
 	| "s3resume" :: _ ->
 		if state.vm_lifestate <> VmRunning then
@@ -831,7 +831,7 @@ let do_trigger xc state args =
 		else if not state.vm_cfg.hvm then
 			Xenvmlib.Error ("cannot do s3resume on a non-hvm guest")
 		else (
-			Domain.send_s3resume ~xc state.vm_domid;
+			Domain.send_s3resume ~xc ~xs state.vm_domid;
 			Xenvmlib.Ok
 		)
 	| _ ->

--- a/xenvm/xenvm.ml
+++ b/xenvm/xenvm.ml
@@ -563,7 +563,7 @@ let do_task state (task, args) =
 		Vmact.set state field value
 	| Tasks.Trigger ->
 		let params = Tasks.args_get_liststring args "params" in
-		with_xc (fun xc -> Vmact.do_trigger xc state params)
+		with_xcs (fun xc xs -> Vmact.do_trigger xc xs state params)
 	| Tasks.SetNicBackendDom ->
 		let id = Int64.to_int (Tasks.args_get_int args "id") in
 		let domid = Int64.to_int (Tasks.args_get_int args "domid") in


### PR DESCRIPTION
**Test note:** Can be merged in any order, but should be tested with: https://github.com/OpenXT/xenclient-oe/pull/189

Currently, the input server is responsible for signaling to QEMU when a domain
has awoken from S3; but:
- This is nonideal, as it requires the input server to be running, and
  requires the input server to circumvent the toolstack for waking guests.
- This means that guests are not woken properly when using toolstack calls,
  such as "xec-vm -n <domain-name> reusume".

This commit modifies the toolstack to send a signal via the XenStore when the
guest should be awoken, notifying QEMU that a guest's device models should be
awoken from their emulated S3.
