### PR TITLE
[xenvm] Remove v4v PV nodes

### DIFF
--- a/xenops/device.ml
+++ b/xenops/device.ml
@@ -1508,35 +1508,6 @@ let add ~xc ~xs ~hvm ~instance domid =
 	in()
 end
 
-
-module V4V = struct
-
-let add ~xc ~xs ~hvm domid =
-	debug "Device.V4V.add %d" domid;
-
-	let frontend = { domid = domid; kind = V4V; devid = 0 } in
-	let backend  = { domid = 0    ; kind = V4V; devid = 0 } in
-	let device   = { backend = backend; frontend = frontend } in
-	let back = [
-		"frontend-id", sprintf "%u" domid;
-		"state", string_of_int (Xenbus.int_of Xenbus.Unknown);
-	] in
-	let front = [
-		"backend-id", string_of_int 0;
-		"state", string_of_int (Xenbus.int_of Xenbus.Initialising);
-	] in
-	Generic.add_device ~xs device back front;
-	()
-
-let hard_shutdown ~xs (x: device) =
-	debug "Device.V4V.hard_shutdown %s" (string_of_device x);
-	()
-
-let clean_shutdown ~xs (x: device) =
-	debug "Device.V4V.clean_shutdown %s" (string_of_device x);
-	()
-end
-
 module Console = struct
 
 type consback = XenConsoled | Ioemu
@@ -1608,7 +1579,6 @@ let hard_shutdown ~xs (x: device) = match (x.backend.kind, x.frontend.kind) with
   | Vfb,_ -> Vfb.hard_shutdown ~xs x
   | Vkb,_ -> Vkb.hard_shutdown ~xs x
   | Vsnd,_ -> Vsnd.hard_shutdown ~xs x
-  | V4V,_ -> V4V.hard_shutdown ~xs x
   | Vtpm,_ -> ()
   | Console,_ -> Console.hard_shutdown ~xs x
 
@@ -1621,7 +1591,6 @@ let clean_shutdown ~xs (x: device) = match (x.backend.kind, x.frontend.kind) wit
   | Vfb,_ -> Vfb.clean_shutdown ~xs x
   | Vkb,_ -> Vkb.clean_shutdown ~xs x
   | Vsnd,_ -> Vsnd.clean_shutdown ~xs x
-  | V4V,_ -> V4V.clean_shutdown ~xs x
   | Vtpm,_ -> ()
   | Console,_ -> Console.clean_shutdown ~xs x
 

--- a/xenops/device.mli
+++ b/xenops/device.mli
@@ -224,11 +224,6 @@ sig
 	val add : xc:Xc.handle -> xs:Xs.xsh -> hvm:bool -> instance:int -> Xc.domid -> unit
 end
 
-module V4V :
-sig
-	val add : xc:Xc.handle -> xs:Xs.xsh -> hvm:bool -> Xc.domid -> unit
-end
-
 module Vsnd :
 sig
 	val add : xc:Xc.handle -> xs:Xs.xsh -> hvm:bool -> Xc.domid -> unit

--- a/xenops/device_common.ml
+++ b/xenops/device_common.ml
@@ -19,7 +19,7 @@ open Stringext
 open Hashtblext
 open Pervasiveext
 
-type kind = Vif | Vwif | Vbd | Tap | Pci | Vfb | Vkb | V4V | Console | Vsnd | Vtpm
+type kind = Vif | Vwif | Vbd | Tap | Pci | Vfb | Vkb | Console | Vsnd | Vtpm
 
 type devid = int
 (** Represents one end of a device *)
@@ -46,9 +46,9 @@ open D
 open Printf
 
 let string_of_kind = function
-  | Vif -> "vif" | Vwif -> "vwif" | Vbd -> "vbd" | Tap -> "tap" | Pci -> "pci" | Vfb -> "vfb" | Vkb -> "vkbd" | V4V -> "v4v" | Console -> "console" | Vsnd -> "vsnd" | Vtpm -> "vtpm"
+  | Vif -> "vif" | Vwif -> "vwif" | Vbd -> "vbd" | Tap -> "tap" | Pci -> "pci" | Vfb -> "vfb" | Vkb -> "vkbd" | Console -> "console" | Vsnd -> "vsnd" | Vtpm -> "vtpm"
 let kind_of_string = function
-  | "vif" -> Vif | "vwif" -> Vwif | "vbd" -> Vbd | "tap" -> Tap | "pci" -> Pci | "vfb" -> Vfb | "vkbd" -> Vkb | "v4v" -> V4V | "console" -> Console | "vsnd" -> Vsnd | "vtpm" -> Vtpm
+  | "vif" -> Vif | "vwif" -> Vwif | "vbd" -> Vbd | "tap" -> Tap | "pci" -> Pci | "vfb" -> Vfb | "vkbd" -> Vkb | "console" -> Console | "vsnd" -> Vsnd | "vtpm" -> Vtpm
   | x -> raise (Unknown_device_type x)
 
 let string_of_endpoint (x: endpoint) =

--- a/xenops/device_common.mli
+++ b/xenops/device_common.mli
@@ -15,7 +15,7 @@
  * GNU Lesser General Public License for more details.
  *)
 
-type kind = Vif | Vwif | Vbd | Tap | Pci | Vfb | Vkb | V4V | Console | Vsnd | Vtpm
+type kind = Vif | Vwif | Vbd | Tap | Pci | Vfb | Vkb | Console | Vsnd | Vtpm
 
 type devid = int
 

--- a/xenops/hotplug.ml
+++ b/xenops/hotplug.ml
@@ -97,7 +97,7 @@ let device_is_online ~xs (x: device) =
   and backend_request () = try ignore(xs.Xs.read (backend_shutdown_request_path_of_device ~xs x)); true with Xb.Noent -> false in
 
   match x.backend.kind with
-  | Pci | Vfb | Vkb | V4V | Console | Vsnd -> assert false (* PCI/Vfb backend doesn't create online node *)
+  | Pci | Vfb | Vkb | Console | Vsnd -> assert false (* PCI/Vfb backend doesn't create online node *)
   | Vif | Vwif -> backend_hotplug ()
   | ( Vbd | Tap ) -> 
       if backend_request () 

--- a/xenvm/vmact.ml
+++ b/xenvm/vmact.ml
@@ -749,9 +749,6 @@ let add_devices xc xs domid state restore =
 		(* Add the PV audio device *)
 		if cfg.vsnd then Device.Vsnd.add ~xc ~xs ~hvm:cfg.hvm domid;
 
-		(* Add the V4V device *)
-                if cfg.v4v then Device.V4V.add ~xc ~xs ~hvm:cfg.hvm domid;
-
 		(* Add the VTPM device *)
 		(match cfg.vtpm_instance with
 		| None -> ()


### PR DESCRIPTION
I have no knowledge how those nodes are used or useful. Juging by the
state of the backend it is not used and only the CAML toolstack creates
both front and back entries.

Remnance of a former experiment?
