### PR TITLE
pci-dm-helper removal

### DIFF
--- a/xenops/dm.ml
+++ b/xenops/dm.ml
@@ -197,7 +197,6 @@ let stubdom_helpers =
 	[
 		{ path = "/usr/lib/xen/bin/atapi_pt_helper" };
 		{ path = "/usr/lib/xen/bin/audio_helper_start" };
-		{ path = "/usr/lib/xen/bin/pci-dm-helper" }
 	]
 		
 let fork_stubdom_helpers ~xs uuid target_domid stubdom_domid =


### PR DESCRIPTION
This helper is no longer useful. It used to handle PCI IO to config.
space and resources from stub-domain'ed QEMU to manage PCI pass-through
in that context.

See https://github.com/OpenXT/xenclient-oe/pull/253

OXT-490
