### PR TITLE
Remove dm-agent from dom0

### DIFF
--- a/libs/common/dbus_conn.ml
+++ b/libs/common/dbus_conn.ml
@@ -198,3 +198,10 @@ let attach bus ev_loop callbacks =
 let detach conn =
 	Conns.remove_conn conn.ev_handle;
 	Eventloop.remove_conn conn.ev_loop conn.ev_handle
+
+let send_msg ~bus ~dest ~path ~intf ~serv ~params =
+	let msg = DBus.Message.new_method_call dest path intf serv in
+	DBus.Message.append msg params;
+	let rep = DBus.Connection.send_with_reply_and_block bus msg (-1) in
+	DBus.Message.get rep
+

--- a/libs/common/dbus_conn.mli
+++ b/libs/common/dbus_conn.mli
@@ -74,3 +74,4 @@ val error_callback : 'a -> Conns.ConnectionMap.key -> Eventloop.error -> unit
 val db_callbacks : Eventloop.conn_callbacks
 val attach : DBus.bus -> Eventloop.t -> callbacks -> t
 val detach : t -> unit
+val send_msg : bus:DBus.bus -> dest:string -> path:string -> intf:string -> serv:string -> params:DBus.ty list -> DBus.ty list

--- a/xenops/Makefile
+++ b/xenops/Makefile
@@ -19,12 +19,14 @@
 TOPLEVEL=..
 include $(TOPLEVEL)/common.make
 
+DBUS_DIR = `ocamlfind query dbus`
 LIBS = xenops.cma xenops.cmxa
 
 OCAMLINCLUDE += \
 	-I $(TOPLEVEL)/libs/log -I $(TOPLEVEL)/libs/xb -I $(TOPLEVEL)/libs/xs -I $(TOPLEVEL)/libs/udev -I $(TOPLEVEL)/libs/uuid \
 	-I $(TOPLEVEL)/libs/mmap -I $(TOPLEVEL)/libs/xc -I $(TOPLEVEL)/libs/xg -I $(TOPLEVEL)/libs/eventchn -I $(TOPLEVEL)/libs/scsi \
-	-I $(TOPLEVEL)/libs/netdev -I $(TOPLEVEL)/libs/stdext -I $(TOPLEVEL)/libs/base64 -I $(TOPLEVEL)/libs/common
+	-I $(TOPLEVEL)/libs/netdev -I $(TOPLEVEL)/libs/stdext -I $(TOPLEVEL)/libs/base64 -I $(TOPLEVEL)/libs/common \
+	-I $(DBUS_DIR)
 OCAMLOPTFLAGS += -thread
 
 OBJS_XENOPS_COMMON = \

--- a/xenops/device.ml
+++ b/xenops/device.ml
@@ -1398,7 +1398,25 @@ let add ~xc ~xs ~hvm ?(protocol=Protocol_Native) domid =
 		"protocol", (string_of_protocol protocol);
 		"state", string_of_int (Xenbus.int_of Xenbus.Initialising);
 	] in
+        let dbus_send_msg ~bus ~dest ~path ~intf ~serv ~params =
+            let msg = DBus.Message.new_method_call dest path intf serv in
+            DBus.Message.append msg params;
+            let rep = DBus.Connection.send_with_reply_and_block bus msg (-1) in
+            DBus.Message.get rep
+            in
+        let dbus_set_pv_display domid =
+            let bus = DBus.Bus.get DBus.Bus.System in
+            let intf = "com.citrix.xenclient.surfman" in
+            let name = intf in
+            let path = "/" in
+            let serv = "set_pv_display" in
+            let params = [ DBus.Int32 0l; DBus.String "" ] in
+            let ret = dbus_send_msg ~bus ~dest:name ~path ~intf ~serv ~params in
+            info "Surfman: DBus.set_pv_display returned:";
+            List.iter (fun o -> info "%s" (DBus.string_of_ty o)) ret
+        in
 	Generic.add_device ~xs device back front;
+        dbus_set_pv_display domid;
 	()
 
 let hard_shutdown ~xs (x: device) =

--- a/xenops/device.mli
+++ b/xenops/device.mli
@@ -217,6 +217,7 @@ end
 module Vkb :
 sig
 	val add : xc:Xc.handle -> xs:Xs.xsh -> hvm:bool -> ?protocol:protocol -> Xc.domid -> int -> unit
+        val dbus_vkbd : Xc.domid -> string -> unit
 end
 
 module Vtpm :

--- a/xenvm/Makefile
+++ b/xenvm/Makefile
@@ -75,7 +75,7 @@ xenvm-cmd_LIBS = unix.cmxa camomile.cmxa threads.cmxa \
 	-ccopt -L -ccopt $(TOPLEVEL)/libs/common $(TOPLEVEL)/libs/common/tscommon.cmxa \
 	-ccopt -L -ccopt $(TOPLEVEL)/libs/stdext $(TOPLEVEL)/libs/stdext/stdext.cmxa
 
-xenops_LIBS = unix.cmxa threads.cmxa \
+xenops_LIBS = unix.cmxa threads.cmxa dBus.cmxa \
 	$(c_libs) \
 	$(TOPLEVEL)/libs/uuid/uuid.cmxa \
 	-ccopt -L -ccopt $(TOPLEVEL)/libs/mmap $(TOPLEVEL)/libs/mmap/mmap.cmxa \
@@ -91,7 +91,8 @@ xenops_LIBS = unix.cmxa threads.cmxa \
 	-ccopt -L -ccopt $(TOPLEVEL)/libs/scsi $(TOPLEVEL)/libs/scsi/scsi.cmxa \
 	-ccopt -L -ccopt $(TOPLEVEL)/libs/base64 $(TOPLEVEL)/libs/base64/base64.cmxa \
 	-ccopt -L -ccopt $(TOPLEVEL)/libs/common $(TOPLEVEL)/libs/common/tscommon.cmxa \
-	-ccopt -L -ccopt $(TOPLEVEL)/xenops $(TOPLEVEL)/xenops/xenops.cmxa
+	-ccopt -L -ccopt $(TOPLEVEL)/xenops $(TOPLEVEL)/xenops/xenops.cmxa \
+	-ccopt -L -ccopt $(DBUS_DIR) $(DBUS_DIR)/dBus.cmxa
 
 PROGRAMS = xenvm xenvm-cmd xenops
 OCAML_PROGRAM = xenvm xenvm-cmd xenops

--- a/xenvm/vmact.ml
+++ b/xenvm/vmact.ml
@@ -718,7 +718,8 @@ let add_devices xc xs domid state restore =
                 (* Add the PV keyboard and mouse devices *)
                 if cfg.vkbd then (
                     Device.Vkb.add ~xc ~xs ~hvm:cfg.hvm ~protocol domid 0;
-                    Device.Vkb.add ~xc ~xs ~hvm:cfg.hvm ~protocol domid 1
+                    Device.Vkb.add ~xc ~xs ~hvm:cfg.hvm ~protocol domid 1;
+                    Device.Vkb.dbus_vkbd domid "attach_vkbd"
                 );
 
                 (* Add the PV framebufer device *)

--- a/xenvm/vmact.ml
+++ b/xenvm/vmact.ml
@@ -292,7 +292,7 @@ let cd_insert_as ~xc ~xs state ty virtpath physpath =
 				Device.Vbd.extra_backend_keys = None;
 			} in
 			debug "adding new media backend for stubdom";
-			Device.Vbd.add_struct ~xc ~xs ~hvm:false diskinfo stubid;
+			ignore (Device.Vbd.add_struct ~xc ~xs ~hvm:false diskinfo stubid);
 			debug "inserting media";
 			Device.Vbd.media_insert ~xs ~virtpath ~physpath ~phystype:ty stubid;
 			Xenvmlib.Ok
@@ -618,7 +618,6 @@ let add_devices xc xs domid state restore =
 	let nics = get_nics cfg in
 
 	(* create disk snapshots, mount vhds *)
-	let org_disks  = cfg.disks in
 	let snap_disks = prepare_disks ~xs state (make_snapshots state.vm_uuid cfg.disks) in
 	let cfg = { cfg with disks = snap_disks } in
 	(* add disks and nics *)
@@ -759,7 +758,10 @@ let add_devices xc xs domid state restore =
 		| None           -> ()
 		| Some stubdomid ->
 			let path = sprintf "/local/domain/%d/power-state" domid in
-			let exists = try xs.Xs.read path; true with _ -> false in
+			let exists =
+                            try ignore (xs.Xs.read path); true
+                            with _ -> false
+                        in
 			if not exists then (
 				xs.Xs.write path ""
 			);
@@ -824,7 +826,6 @@ let change_vmstate state newstate =
 	)
 
 let stop_vm xc xs state =
-	let domid = state.vm_domid in
 	if state.vm_domid = -1 then
 		warn "not destroying domain: domid = -1"
 	else (

--- a/xenvm/vmact.ml
+++ b/xenvm/vmact.ml
@@ -737,7 +737,8 @@ let add_devices xc xs domid state restore =
 			debug "add_devices: adding vtpm device, backend=%d instance=%d" cfg.vtpm_backend instance;
 			Device.Vtpm.add ~xc ~xs ~hvm:cfg.hvm domid ~instance
 		);
-		if cfg.hvm || cfg.qemu_pv then (
+                (* Only start dmagent for hvm guests *)
+		if cfg.hvm then (
 			(* add device model *)
 			debug "add_devices: adding device model";
 			if use_dm then (

--- a/xenvm/xenvm.ml
+++ b/xenvm/xenvm.ml
@@ -442,13 +442,10 @@ let monitor_vm state =
 let do_task state (task, args) =
 	let optional_arg default f args s =
 		try f args s with Tasks.Argument_not_found _ -> default
-		in
+	in
 	let optional_arg_nodef f args s =
 		try Some (f args s) with Tasks.Argument_not_found _ -> None
-		in
-
-	let task_desc = List.assoc task Tasks.actions_table in
-	(*maybe assert_vmstate task_vmstate_required;*)
+	in
 	match task with
 	| Tasks.Quit ->
 		notify_quit state; Xenvmlib.Ok
@@ -607,12 +604,7 @@ let do_task state (task, args) =
 		Xenvmlib.Ok
 
 let monitor_rpc_json socket state =
-	let assert_vmstate expected =
-		if expected <> state.vm_lifestate then
-			raise (Vmact.Vm_bad_state (expected, state.vm_lifestate));
-		in
 	let connections = ref [] in
-
 	let reply_error con error =
 		let s = Jsonrpc.response_to_string error in
 		thread_create (fun () ->
@@ -780,14 +772,12 @@ let introspect state msg =
 let monitor_rpc_dbus state =
 	let use_session = state.vm_monitors.monitor_use_dbus_session in
 	let intf = Printf.sprintf "org.xen.vm.uuid_%s" (String.replace "-" "_" state.vm_uuid) in
-	let match_s = sprintf "type='method',interface='%s'" intf in
 	let bus = DBus.Bus.get (if use_session then DBus.Bus.Session else DBus.Bus.System) in
 	let reply = DBus.Bus.request_name bus intf [ DBus.Bus.DoNotQueue ] in
 	(match reply with
 	| DBus.Bus.PrimaryOwner -> ()
 	| _                     -> failwith (Printf.sprintf "cannot grab dbus intf %s" intf)
 	);
-	(*DBus.Bus.add_match bus match_s false;*)
 	(* listen to Network Manager notificatons *)
 	DBus.Bus.add_match bus "type='signal',interface='org.freedesktop.NetworkManager.Device'" false;
 


### PR DESCRIPTION
Fix a couple of CAML warnings.

Use a DBus interface for dom0->dom0 messages with Surfman and Input-server in order for a Linux PV guest to have a Vfb (xenfb/xenfb2) and a Vkbd (keyboard and mouse PV) device. 

OXT-544
