### PR TITLE
[QEMU-2.6.2] Bump stubdom memory to 128

### DIFF
--- a/xenvm/vmconfig.ml
+++ b/xenvm/vmconfig.ml
@@ -806,7 +806,7 @@ let empty =
 		flask_label = None;
 		cores_per_socket = None;
 		stubdom = None;
-		stubdom_memory = 80L;
+		stubdom_memory = 128L;
 		stubdom_initrd = Some "/usr/lib/xen/boot/stubdomain-initramfs";
 		stubdom_kernel = "/usr/lib/xen/boot/stubdomain-bzImage";
 		stubdom_cmdline = "init=/init xen_blkfront.max=8";


### PR DESCRIPTION
This is currently needed because the new QEMU is bigger and pulls in other
big libs (like glibc). We may be able to fix this later. This is addressed
in OXT-782.

OXT-769

Signed-off-by: Ross Philipson <philipsonr@ainfosec.com>