### PR TITLE
Align xenbus object with new header in 4.6 xen

### DIFF
--- a/libs/xb/op.ml
+++ b/libs/xb/op.ml
@@ -20,7 +20,7 @@ type operation = Debug | Directory | Read | Getperms |
                  Getdomainpath | Write | Mkdir | Rm |
                  Setperms | Watchevent | Error | Isintroduced |
                  Resume | Set_target
-               | Restrict 
+               | Restrict | XSReset_watches | XSInvalid 
 
 (* There are two sets of XB operations: the one coming from open-source and *)
 (* the one coming from our private patch queue. These operations            *)
@@ -31,13 +31,13 @@ let operation_c_mapping =
            Transaction_end; Introduce; Release;
            Getdomainpath; Write; Mkdir; Rm;
            Setperms; Watchevent; Error; Isintroduced;
-           Resume; Set_target |]
+           Resume; Set_target; |]
 let size = Array.length operation_c_mapping
 
 (* [offset_pq] has to be the same as in <xen/io/xs_wire.h> *)
 let offset_pq = size
 let operation_c_mapping_pq =
-	[| Restrict |]
+	[| Restrict; XSReset_watches; XSInvalid |]
 let size_pq = Array.length operation_c_mapping_pq
 
 let array_search el a =
@@ -82,3 +82,6 @@ let to_string ty =
 	| Resume		-> "RESUME"
 	| Set_target		-> "SET_TARGET"
 	| Restrict		-> "RESTRICT"
+	| XSReset_watches -> "RESET_WATCHES"
+    | XSInvalid       -> "INVALID"
+			

--- a/libs/xb/op.ml
+++ b/libs/xb/op.ml
@@ -31,7 +31,7 @@ let operation_c_mapping =
            Transaction_end; Introduce; Release;
            Getdomainpath; Write; Mkdir; Rm;
            Setperms; Watchevent; Error; Isintroduced;
-           Resume; Set_target; |]
+           Resume; Set_target |]
 let size = Array.length operation_c_mapping
 
 (* [offset_pq] has to be the same as in <xen/io/xs_wire.h> *)

--- a/libs/xb/xb.mli
+++ b/libs/xb/xb.mli
@@ -40,6 +40,8 @@ sig
 		| Resume
 		| Set_target
 		| Restrict
+		| XSReset_watches
+		| XSInvalid
 	val to_string : operation -> string
 end
 


### PR DESCRIPTION
Fixes an occasional segfault in xenstored.

Signed-off-by: Chris Rogers <rogersc@ainfosec.com>