### PR TITLE
[libxl] Cleanup xapi nodes in xenstore

### DIFF
--- a/scripts/block
+++ b/scripts/block
@@ -28,6 +28,6 @@ add)
         xenstore-write "${XAPI}/hotplug" "online"
         ;;
 remove)
-        xenstore-rm "${XAPI}/hotplug"
+        xenstore-rm "/xapi/${DOMID}"
         ;;
 esac


### PR DESCRIPTION
  When a domain shuts down, the block script is run to cleanup
  xapi entries specifically for vbds. Only one node is rm'd, which
  leaves behind <domid>/hotplug/vbd/<vbdid> in the xenstore.
  These quickly accumulate and lead to a messy xenstore.

  OXT-965

Signed-off-by: Chris <rogersc@ainfosec.com>