### PR TITLE
[Xen 4.9] Write additional xenstore nodes in block hotplug script

### DIFF
--- a/scripts/block
+++ b/scripts/block
@@ -25,6 +25,10 @@ XAPI=/xapi/${DOMID}/hotplug/${TYPE}/${DEVID}
 
 case "$1" in
 add)
+        PARAMS=$(xenstore-read "${XENBUS_PATH}/params")
+        MINOR=$(stat -c '%T' ${PARAMS})
+        xenstore-write "${XENBUS_PATH}/physical-device" "fe:${MINOR}"
+        xenstore-write "${XENBUS_PATH}/physical-device-path" "${PARAMS}"
         xenstore-write "${XAPI}/hotplug" "online"
         ;;
 remove)


### PR DESCRIPTION
OXT-1203 for Xen upgrade.

Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>