### PR TITLE
OXT-1203: block: do not write physical-device for atapi-pt devices

### DIFF
--- a/scripts/block
+++ b/scripts/block
@@ -26,9 +26,11 @@ XAPI=/xapi/${DOMID}/hotplug/${TYPE}/${DEVID}
 case "$1" in
 add)
         PARAMS=$(xenstore-read "${XENBUS_PATH}/params")
-        MINOR=$(stat -c '%T' ${PARAMS})
-        xenstore-write "${XENBUS_PATH}/physical-device" "fe:${MINOR}"
-        xenstore-write "${XENBUS_PATH}/physical-device-path" "${PARAMS}"
+        if [[ ${PARAMS} != atapi-pt* ]]; then
+          MINOR=$(stat -c '%T' ${PARAMS})
+          xenstore-write "${XENBUS_PATH}/physical-device" "fe:${MINOR}"
+          xenstore-write "${XENBUS_PATH}/physical-device-path" "${PARAMS}"
+        fi
         xenstore-write "${XAPI}/hotplug" "online"
         ;;
 remove)


### PR DESCRIPTION
OXT-1203

Signed-off-by: Jed <lejosnej@ainfosec.com>