### PR TITLE
STABLE-6: OXT-1218: Upgrade Xen to 4.6.6.

### DIFF
--- a/libs/xb/op.ml
+++ b/libs/xb/op.ml
@@ -20,7 +20,7 @@ type operation = Debug | Directory | Read | Getperms |
                  Getdomainpath | Write | Mkdir | Rm |
                  Setperms | Watchevent | Error | Isintroduced |
                  Resume | Set_target
-               | Restrict 
+               | Restrict | XSReset_watches | XSInvalid 
 
 (* There are two sets of XB operations: the one coming from open-source and *)
 (* the one coming from our private patch queue. These operations            *)
@@ -31,13 +31,13 @@ let operation_c_mapping =
            Transaction_end; Introduce; Release;
            Getdomainpath; Write; Mkdir; Rm;
            Setperms; Watchevent; Error; Isintroduced;
-           Resume; Set_target |]
+           Resume; Set_target; |]
 let size = Array.length operation_c_mapping
 
 (* [offset_pq] has to be the same as in <xen/io/xs_wire.h> *)
 let offset_pq = size
 let operation_c_mapping_pq =
-	[| Restrict |]
+	[| Restrict; XSReset_watches; XSInvalid |]
 let size_pq = Array.length operation_c_mapping_pq
 
 let array_search el a =
@@ -82,3 +82,6 @@ let to_string ty =
 	| Resume		-> "RESUME"
 	| Set_target		-> "SET_TARGET"
 	| Restrict		-> "RESTRICT"
+	| XSReset_watches -> "RESET_WATCHES"
+    | XSInvalid       -> "INVALID"
+			

--- a/libs/xb/op.ml
+++ b/libs/xb/op.ml
@@ -31,7 +31,7 @@ let operation_c_mapping =
            Transaction_end; Introduce; Release;
            Getdomainpath; Write; Mkdir; Rm;
            Setperms; Watchevent; Error; Isintroduced;
-           Resume; Set_target; |]
+           Resume; Set_target |]
 let size = Array.length operation_c_mapping
 
 (* [offset_pq] has to be the same as in <xen/io/xs_wire.h> *)

--- a/libs/xb/xb.mli
+++ b/libs/xb/xb.mli
@@ -40,6 +40,8 @@ sig
 		| Resume
 		| Set_target
 		| Restrict
+		| XSReset_watches
+		| XSInvalid
 	val to_string : operation -> string
 end
 

--- a/libs/xc/xc.ml
+++ b/libs/xc/xc.ml
@@ -254,7 +254,6 @@ external domain_set_vpt_align: handle -> domid -> int -> unit = "stub_xc_domain_
 
 external domain_send_s3resume: handle -> domid -> unit = "stub_xc_domain_send_s3resume"
 external domain_get_acpi_s_state: handle -> domid -> int = "stub_xc_domain_get_acpi_s_state"
-external domain_set_xci_service: handle -> domid -> bool -> unit = "stub_xc_domain_set_xci_service"
 
 external domain_disable_migrate: handle -> domid -> unit = "stub_xc_domain_disable_migrate"
 

--- a/libs/xc/xc.mli
+++ b/libs/xc/xc.mli
@@ -199,8 +199,6 @@ external domain_get_acpi_s_state: handle -> domid -> int = "stub_xc_domain_get_a
 external domain_set_target: handle -> domid -> domid -> unit
 	= "stub_xc_domain_set_target"
 
-external domain_set_xci_service: handle -> domid -> bool -> unit = "stub_xc_domain_set_xci_service"
-
 external domain_disable_migrate: handle -> domid -> unit = "stub_xc_domain_disable_migrate"
 
 external hvm_check_pvdriver : handle -> domid -> bool = "stub_xc_hvm_check_pvdriver"

--- a/libs/xg/xg_stubs.c
+++ b/libs/xg/xg_stubs.c
@@ -470,13 +470,13 @@ CAMLprim value stub_xc_domain_save(value handle, value fd, value domid,
 	c_domid = _D(domid);
 
 	memset(&callbacks, 0, sizeof(callbacks));
-	callbacks.data = c_domid;
+	callbacks.data = (void*)c_domid;
 	callbacks.suspend = dispatch_suspend;
 
 	caml_enter_blocking_section();
 	r = xc_domain_save(_H(handle), Int_val(fd), c_domid,
 	                   Int_val(max_iters), Int_val(max_factors),
-	                   c_flags, &callbacks, Bool_val(hvm), 0);
+	                   c_flags, &callbacks, Bool_val(hvm));
 	caml_leave_blocking_section();
 	if (r)
 		failwith_oss_xc(_H(handle), "xc_domain_save");
@@ -535,7 +535,7 @@ CAMLprim value stub_xc_domain_restore(value handle, value fd, value domid, value
 	                      c_store_evtchn, &store_mfn, _D(domid),
 	                      c_console_evtchn, &console_mfn, _D(domid),
 			      Bool_val(hvm), f.pae, 0 /*superpages*/,
-		              1, 0, NULL, NULL);
+		              0, NULL);
 	caml_leave_blocking_section();
 	if (r)
 		failwith_oss_xc(_H(handle), "xc_domain_restore");

--- a/libs/xg/xg_stubs.c
+++ b/libs/xg/xg_stubs.c
@@ -28,6 +28,7 @@
 #include <xen/hvm/hvm_xs_strings.h>
 #include <xen/hvm/params.h>
 #include <xen/hvm/e820.h>
+#include <xc_dom.h>
 #include <sys/mman.h>
 #include "xg_utils.h"
 #include <xentoollog.h>

--- a/libs/xg/xg_stubs.c
+++ b/libs/xg/xg_stubs.c
@@ -28,7 +28,6 @@
 #include <xen/hvm/hvm_xs_strings.h>
 #include <xen/hvm/params.h>
 #include <xen/hvm/e820.h>
-#include <xc_dom.h>
 #include <sys/mman.h>
 #include "xg_utils.h"
 #include <xentoollog.h>

--- a/xenvm/vmact.ml
+++ b/xenvm/vmact.ml
@@ -1049,10 +1049,7 @@ let build_vm xc xs state f restore =
 		set_cpuid xc domid cfg;
 		set_affinity xc domid cfg;
 		set_cores_per_socket xc domid cfg;
-		if cfg.xciservice then (
-			info "extended service vm permissions enabled";
-			Xc.domain_set_xci_service xc domid true
-		);
+
 		change_vmstate state VmCreatingDevices;
 
 		add_devices xc xs domid state restore;

--- a/xenvm/vmact.ml
+++ b/xenvm/vmact.ml
@@ -1033,13 +1033,6 @@ let build_vm xc xs state f restore =
 	let cfg = state.vm_cfg in
 	let domid = state.vm_domid in
 	try
-		let dom_path = xs.Xs.getdomainpath domid in
-		Xs.transaction xs
-			(fun t ->
-				 List.iter (fun (k,v) ->
-						    t.Xst.write (dom_path ^ "/bios-strings/" ^ k) v
-					   ) cfg.bios_strings
-			);
 		Unixext.with_flock_ex buildlock_fd (fun () -> f state cfg);
 
 		if cfg.disable_migrate then (

--- a/xenvm/vmconfig.ml
+++ b/xenvm/vmconfig.ml
@@ -706,11 +706,6 @@ let list_add cfg field value =
 			(startreg, endreg)
 		| _            -> failwith "bad format for passthrough io. expecting int-int"
 		in
-	let config_bios_string_of_string s =
-		match String.split ~limit:2 '=' s with
-		| k :: v :: [] -> k, v
-		| _            -> failwith "bad format for bios-string. expecting k=v"
-		in
 
 	match field with
 	| "disk"        -> { cfg with disks = cfg.disks @ [ config_disk_of_string value ] }
@@ -724,7 +719,6 @@ let list_add cfg field value =
 	| "cpus-affinity"     -> { cfg with cpus_affinity = cfg.cpus_affinity @ [ config_cpus_affinity_of_string value ] }
 	| "passthrough-io"    -> { cfg with passthrough_ios = cfg.passthrough_ios @ [ config_passthrough_io_of_string value ] }
 	| "passthrough-mmio"  -> { cfg with passthrough_mmios = cfg.passthrough_mmios @ [ config_passthrough_mmio_of_string value ] }
-	| "bios-string"       -> { cfg with bios_strings = cfg.bios_strings @ [ config_bios_string_of_string value ] }
 	| _             -> raise (Unknown_field field)
 
 let list_del cfg field index =
@@ -868,7 +862,7 @@ let of_file uuid error_report file =
 		match k with
 		| "disk" | "vif" | "nic" | "pci" | "cpuid" | "cpus-affinity"
 		| "extra-hvm" | "extra-local-watch" | "extra-vm-watch"
-		| "passthrough-io" | "passthrough-mmio" | "bios-string" | "platform" ->
+		| "passthrough-io" | "passthrough-mmio" | "platform" ->
 			cfg := list_add !cfg k v
 		| "on_halt"    -> cfg := { !cfg with on_halt    = action_of_string v }
 		| "on_restart" -> cfg := { !cfg with on_restart = action_of_string v }


### PR DESCRIPTION
Backport changes and fixes made to the toolstack during the Xen 4.6.1 upgrade in master.
Linked to:
- https://github.com/OpenXT/xenclient-oe/pull/770
- https://github.com/OpenXT/openxt/pull/267