### PR TITLE
STABLE-6: Write drive information to xenstore even when there's no hard drive

### DIFF
--- a/xenops/dmagent.ml
+++ b/xenops/dmagent.ml
@@ -296,7 +296,8 @@ let need_device info device =
 	| "serial" -> info.Dm.hvm && info.Dm.serial <> ""
 	| "net" -> info.Dm.hvm && info.Dm.nics <> []
 	| "drive" -> info.Dm.hvm && List.fold_left (fun b disk -> b ||
-								disk.Device.Vbd.dev_type = Device.Vbd.Disk)
+							disk.Device.Vbd.dev_type = Device.Vbd.Disk ||
+							disk.Device.Vbd.dev_type = Device.Vbd.CDROM)
 								false info.Dm.disks
 	| "cdrom" -> (in_stubdom info && List.fold_left (fun b disk -> b ||
 					disk.Device.Vbd.dev_type = Device.Vbd.CDROM) false


### PR DESCRIPTION
OXT-1238

Signed-off-by: Jed <lejosnej@ainfosec.com>