### PR TITLE
blktap3: move physical-device xenstore node creation back to libxl

### DIFF
--- a/scripts/block
+++ b/scripts/block
@@ -27,7 +27,6 @@ case "$1" in
 add)
         PARAMS=$(xenstore-read "${XENBUS_PATH}/params")
         MINOR=$(stat -c '%T' ${PARAMS})
-        xenstore-write "${XENBUS_PATH}/physical-device" "fe:${MINOR}"
         xenstore-write "${XENBUS_PATH}/physical-device-path" "${PARAMS}"
         xenstore-write "${XAPI}/hotplug" "online"
         ;;


### PR DESCRIPTION
OXT-1221
Signed-off-by: mahantesh <mahantesh.openxt@gmail.com>