### PR TITLE
STABLE-8: toolstack: Pass -fPIC to CFLAGS

### DIFF
--- a/common.make
+++ b/common.make
@@ -11,12 +11,11 @@ CFLAGS ?= -Wall -fPIC -O2
 XEN_ROOT ?= $(TOPLEVEL)/../xen-unstable.hg
 XEN_DIST_ROOT ?= $(XEN_ROOT)/dist/install
 CFLAGS += -I$(XEN_DIST_ROOT)/usr/include
+CFLAGS += -fPIC
 
 OCAMLOPTFLAG_G := $(shell $(OCAMLOPT) -h 2>&1 | sed -n 's/^  *\(-g\) .*/\1/p')
 OCAMLOPTFLAGS = $(OCAMLOPTFLAG_G) -ccopt "$(LDFLAGS)" -dtypes $(OCAMLINCLUDE) -cc "$(CC)" -w F -warn-error F
 OCAMLCFLAGS += -g $(OCAMLINCLUDE) -w F -warn-error F
-
-#LDFLAGS = -cclib -L./
 
 DESTDIR ?= /
 VERSION := echo 0.0

--- a/libs/stdext/Makefile
+++ b/libs/stdext/Makefile
@@ -45,7 +45,6 @@ OCAML_LIBRARY = stdext
 
 ## OBJS
 threadext.cmo: threadext.ml
-	echo $LDFLAGS
 	$(call quiet-command, $(OCAMLC) $(OCAMLCFLAGS) -thread -c -o $@ $<,MLC,$@)
 
 threadext.cmi: threadext.mli


### PR DESCRIPTION
Was reported by bitbake:

```
WARNING: xenclient-toolstack-0+gitAUTOINC+b22cf03e5a-r0 do_package_qa: QA Issue: ELF binary '/home/build/openxt/pyro-2/tmp-glibc/work/xenclient_dom0-oe-linux/xenclient-toolstack/0+gitAUTOINC+b22cf03e5a-r0/packages-split/xenclient-toolstack-libs/usr/lib/ocaml/site-lib/stdext/dllstdext_stubs.so' has relocations in .text
ELF binary '/home/build/openxt/pyro-2/tmp-glibc/work/xenclient_dom0-oe-linux/xenclient-toolstack/0+gitAUTOINC+b22cf03e5a-r0/packages-split/xenclient-toolstack-libs/usr/lib/ocaml/site-lib/log/dllsyslog_stubs.so' has relocations in .text [textrel]
```