### PR TITLE
udev: Package and revise udev hotplug rules

### DIFF
--- a/scripts/xen-backend.rules
+++ b/scripts/xen-backend.rules
@@ -1,7 +1,0 @@
-SUBSYSTEM=="xen-backend", KERNEL=="tap*", RUN+="/etc/xen/scripts/tap $env{ACTION}"
-SUBSYSTEM=="xen-backend", KERNEL=="vbd*", RUN+="/etc/xen/scripts/block $env{ACTION}"
-SUBSYSTEM=="xen-backend", KERNEL=="vif*", RUN+="/etc/xen/scripts/vif $env{ACTION}"
-KERNEL=="evtchn", NAME="xen/%k",SYMLINK+="xen/eventchn"
-
-# blktap devices created by blktapctrl
-KERNEL=="blktap[0-9]*", OPTIONS="ignore_device"

--- a/scripts/xen-block-backend.rules
+++ b/scripts/xen-block-backend.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="xen-backend", KERNEL=="vbd*", RUN+="/etc/xen/scripts/block $env{ACTION}"

--- a/scripts/xen-frontend.rules
+++ b/scripts/xen-frontend.rules
@@ -1,1 +1,0 @@
-SUBSYSTEM=="block", KERNEL=="xvd*", RUN+="/etc/xen/scripts/block-frontend $env{ACTION} $number"

--- a/scripts/xen-tap-backend.rules
+++ b/scripts/xen-tap-backend.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="xen-backend", KERNEL=="tap*", RUN+="/etc/xen/scripts/tap $env{ACTION}"

--- a/scripts/xen-vif-backend.rules
+++ b/scripts/xen-vif-backend.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="xen-backend", KERNEL=="vif*", RUN+="/etc/xen/scripts/vif $env{ACTION}"


### PR DESCRIPTION
With the upstream scripts now being used, revise
and package the rules accordingly.  Separate the
legacy scripts into their own package for backwards
compatibility.

OXT-1356

Signed-off-by: Tim Konick <konickt@ainfosec.com>