### PR TITLE
Run udev vif script on vwif interfaces too

### DIFF
--- a/scripts/xen-vif-backend.rules
+++ b/scripts/xen-vif-backend.rules
@@ -1,1 +1,1 @@
-SUBSYSTEM=="xen-backend", KERNEL=="vif*", RUN+="/etc/xen/scripts/vif $env{ACTION}"
+SUBSYSTEM=="xen-backend", KERNEL=="vif*|vwif*", RUN+="/etc/xen/scripts/vif $env{ACTION}"


### PR DESCRIPTION
This is necessary at least since the hotplug-status xenstore node
is now created by the vif script, as opposed to xl.

Signed-off-by: Jed <lejosnej@ainfosec.com>