### PR TITLE
OXT-1704: Makefile: Use wildcard instead of globing.

### DIFF
--- a/libs/log/Makefile
+++ b/libs/log/Makefile
@@ -51,14 +51,17 @@ syslog.mli : syslog.ml
 
 .PHONY: install uninstall stage
 install: $(LIBS) META
-	ocamlfind install -destdir $(DESTDIR)$(shell ocamlfind printconf destdir) -ldconf ignore log META $(INTF) $(LIBS) *.a *.so *.cmx
+	ocamlfind install -destdir $(DESTDIR)$(shell ocamlfind printconf destdir) \
+		-ldconf ignore log META $(INTF) $(LIBS) \
+		$(wildcard *.a) $(wildcard *.so) $(wildcard *.cmx)
 
 uninstall:
 	ocamlfind remove log
 
 stage: libs META
 	ocamlfind remove log
-	ocamlfind install log -ldconf ignore META $(INTF) $(LIBS) *.a *.so *.cmx
+	ocamlfind install log -ldconf ignore META $(INTF) $(LIBS) \
+		$(wildcard *.a) $(wildcard *.so) $(wildcard *.cmx)
 
 include $(TOPLEVEL)/Makefile.rules
 

--- a/libs/stdext/Makefile
+++ b/libs/stdext/Makefile
@@ -56,14 +56,17 @@ threadext.cmx: threadext.ml
 .PHONY: install uninstall stage
 
 install: $(LIBS) META
-	ocamlfind install -destdir $(DESTDIR)$(shell ocamlfind printconf destdir) -ldconf ignore stdext META $(INTF) $(LIBS) *.a *.so *.cmx
+	ocamlfind install -destdir $(DESTDIR)$(shell ocamlfind printconf destdir) \
+		-ldconf ignore stdext META $(INTF) $(LIBS) \
+		$(wildcard *.a) $(wildcard *.so) $(wildcard *.cmx)
 
 uninstall:
 	ocamlfind remove stdext
 
 stage: libs META
 	ocamlfind remove stdext
-	ocamlfind install stdext -ldconf ignore META $(INTF) $(LIBS) *.a *.so *.cmx
+	ocamlfind install stdext -ldconf ignore META $(INTF) $(LIBS) \
+		$(wildcard *.a) $(wildcard *.so) $(wildcard *.cmx)
 
 
 include $(TOPLEVEL)/Makefile.rules


### PR DESCRIPTION
Required for: https://github.com/OpenXT/meta-openxt-ocaml-platform/pull/14.